### PR TITLE
Use minimal required maven version in pom.xml

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
 
   <name>Maven Frontend Plugin</name>
   <prerequisites>
-    <maven>3.6.0</maven>
+    <maven>3.2.5</maven>
   </prerequisites>
 
   <description>


### PR DESCRIPTION
**Summary**
Some of us are stuck using older versions of maven and the projects builds with 3.2.5.
Any lower and maven-compiler-plugin complains.

**Tests and Documentation**
Not quite sure what is necessary to validate this, 3.2.5 can package the jar and works for my use case.